### PR TITLE
Encode help strings

### DIFF
--- a/.changeset/chilled-eyes-greet.md
+++ b/.changeset/chilled-eyes-greet.md
@@ -1,0 +1,11 @@
+---
+"metriq": minor
+"@metriq/express": minor
+"@metriq/fastify": minor
+"@metriq/nestjs": minor
+"@metriq/benchmarks": minor
+"@metriq/examples-basic": minor
+"@metriq/examples-nestjs": minor
+---
+
+Encode help string

--- a/metriq/src/exporters/prometheus-formatter.test.ts
+++ b/metriq/src/exporters/prometheus-formatter.test.ts
@@ -912,11 +912,12 @@ describe("PrometheusFormatter", () => {
             formatter = new PrometheusFormatterImpl(metrics);
         });
 
-        describe("label values", () => {
+        describe("text values", () => {
             it("should escape double quotes", async () => {
                 // Arrange
-                const counter = metrics.createCounter("counter", "description");
-                counter.increment({ key: 'value"with"double"quotes' }, 5);
+                const specialString = 'value"with"double"quotes';
+                const counter = metrics.createCounter("counter", specialString);
+                counter.increment({ key: specialString }, 5);
 
                 // Act
                 const stream = formatter.writeMetrics();
@@ -924,16 +925,17 @@ describe("PrometheusFormatter", () => {
 
                 // Assert
                 expect(result).toBe(dedent`
-                # HELP counter description
-                # TYPE counter counter
-                counter{key="value\"with\"double\"quotes"} 5\n
-            `);
+                    # HELP counter value\"with\"double\"quotes
+                    # TYPE counter counter
+                    counter{key="value\"with\"double\"quotes"} 5\n
+                `);
             });
 
             it("should escape backslashes", async () => {
                 // Arrange
-                const counter = metrics.createCounter("counter", "description");
-                counter.increment({ key: "value\\with\\backslashes" }, 5);
+                const specialString = "value\\with\\backslashes";
+                const counter = metrics.createCounter("counter", specialString);
+                counter.increment({ key: specialString }, 5);
 
                 // Act
                 const stream = formatter.writeMetrics();
@@ -941,16 +943,17 @@ describe("PrometheusFormatter", () => {
 
                 // Assert
                 expect(result).toBe(dedent`
-                # HELP counter description
-                # TYPE counter counter
-                counter{key="value\\with\\backslashes"} 5\n
-            `);
+                    # HELP counter value\\with\\backslashes
+                    # TYPE counter counter
+                    counter{key="value\\with\\backslashes"} 5\n
+                `);
             });
 
             it("should escape newlines", async () => {
                 // Arrange
-                const counter = metrics.createCounter("counter", "description");
-                counter.increment({ key: "value\nwith\nnewlines" }, 5);
+                const specialString = "value\nwith\nnewlines";
+                const counter = metrics.createCounter("counter", specialString);
+                counter.increment({ key: specialString }, 5);
 
                 // Act
                 const stream = formatter.writeMetrics();
@@ -959,15 +962,16 @@ describe("PrometheusFormatter", () => {
                 // Assert
                 expect(result).toBe(
                     dedent(`
-                # HELP counter description
-                # TYPE counter counter
-                counter{key="value\\nwith\\nnewlines"} 5`) + "\n",
+                    # HELP counter value\\nwith\\nnewlines
+                    # TYPE counter counter
+                    counter{key="value\\nwith\\nnewlines"} 5`) + "\n",
                 );
             });
 
             it("should replace undefined values with empty strings", async () => {
                 // Arrange
-                const counter = metrics.createCounter("counter", "description");
+                // @ts-expect-error - description is undefined
+                const counter = metrics.createCounter("counter", undefined);
                 counter.increment({ key: undefined }, 5);
 
                 // Act
@@ -976,9 +980,10 @@ describe("PrometheusFormatter", () => {
 
                 // Assert
                 expect(result).toBe(dedent`
-                    # HELP counter description
+                    # HELP counter 
                     # TYPE counter counter
-                    counter{key=""} 5\n`);
+                    counter{key=""} 5\n
+                `);
             });
 
             it("should throw error if label value is not a string", async () => {

--- a/metriq/src/exporters/prometheus-text-utils.ts
+++ b/metriq/src/exporters/prometheus-text-utils.ts
@@ -2,13 +2,13 @@ const QUOTE = 34; // '"'  -> 0x22
 const BACKSL = 92; // '\'  -> 0x5c
 const NEWLINE = 10; // '\n' -> 0x0a
 
-export function escapeLabelValue(str: string | undefined): string {
+export function encodeStringValue(str: string | undefined): string {
     if (typeof str !== "string") {
         if (typeof str === "undefined") {
             return "";
         }
 
-        throw new Error("Label value is not a string");
+        throw new Error("Value is not a string");
     }
 
     let out = "";
@@ -33,7 +33,7 @@ export function escapeLabelValue(str: string | undefined): string {
     return out;
 }
 
-export function encodeMetricValue(value: number): string {
+export function encodeNumericValue(value: number): string {
     if (typeof value !== "number") {
         throw new Error("Value is not a number");
     }


### PR DESCRIPTION
This pull request introduces updates to the Prometheus exporter to improve the handling and encoding of metric values and descriptions. It replaces the existing escape functions with more general-purpose encoding functions, updates test cases to reflect these changes, and modifies the behavior for handling undefined values. Below are the key changes grouped by theme:

### Prometheus Exporter Enhancements:
* Replaced `escapeLabelValue` with `encodeStringValue` and `encodeMetricValue` with `encodeNumericValue` for better naming consistency and functionality. These functions now handle encoding for both strings and numbers in metric descriptions and labels. (`metriq/src/exporters/prometheus-formatter.ts`, `metriq/src/exporters/prometheus-text-utils.ts`) [[1]](diffhunk://#diff-01b1fcfaa66e38917cc65cced3205adec1cb25d908ab5302684649dcc7abfc41L7-R7) [[2]](diffhunk://#diff-01b1fcfaa66e38917cc65cced3205adec1cb25d908ab5302684649dcc7abfc41L41-R69) [[3]](diffhunk://#diff-01b1fcfaa66e38917cc65cced3205adec1cb25d908ab5302684649dcc7abfc41L97-R97) [[4]](diffhunk://#diff-048d46d04103992c8dc348c10c3a6979998d06287f6342104dad19a2ad1ef271L5-R11) [[5]](diffhunk://#diff-048d46d04103992c8dc348c10c3a6979998d06287f6342104dad19a2ad1ef271L36-R36)
* Updated the `writeCounter`, `writeGauge`, and `writeHistogram` methods in `PrometheusFormatterImpl` to use the new encoding functions for metric descriptions and values. (`metriq/src/exporters/prometheus-formatter.ts`)

### Test Case Updates:
* Modified test cases in `prometheus-formatter.test.ts` to validate the new encoding behavior, including escaping special characters (e.g., double quotes, backslashes, and newlines) in metric descriptions and labels. (`metriq/src/exporters/prometheus-formatter.test.ts`) [[1]](diffhunk://#diff-dbc4cdec484ea1ef3eda9139977f43b3cd6a468f4d299d5a82c7a6e9cbfffbc6L915-R956) [[2]](diffhunk://#diff-dbc4cdec484ea1ef3eda9139977f43b3cd6a468f4d299d5a82c7a6e9cbfffbc6L962-R974)
* Added a test case to handle undefined values, ensuring they are replaced with empty strings in metric descriptions and labels. (`metriq/src/exporters/prometheus-formatter.test.ts`)

### Documentation and Metadata:
* Added a changeset file to document the minor version updates for multiple packages, reflecting the improvements to the Prometheus exporter. (`.changeset/chilled-eyes-greet.md`)